### PR TITLE
プロトタイプ投稿機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,7 @@ bh_unicode_properties.cache
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
 
-
+*.png
+*.jpg
+*.jpeg
+*.gif

--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,4 @@ end
   gem 'erb2haml'
   gem 'bootstrap-sass'
   gem 'devise'
+  gem 'carrierwave'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,12 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.2)
     byebug (9.0.5)
+    carrierwave (0.11.2)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
+      mimemagic (>= 0.3.0)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -99,6 +105,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.1)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.12.1)
@@ -192,6 +199,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   byebug
+  carrierwave
   coffee-rails (~> 4.1.0)
   devise
   erb2haml

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -9,7 +9,8 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.new
     # ↓後でmainとsubでbuild方法を変数に入れ直して、fields_forの第二引数に入れて区別する必要あり
     # 理由としては、デフォルトで何かしらで画像が入っていないと、特にサブの場合変わったviewになる
-    @prototype.prototype_images.build
+    @main_content = @prototype.prototype_images.build
+    @sub_contents = 2.times { @prototype.prototype_images.build }
   end
 
   def show
@@ -34,7 +35,7 @@ class PrototypesController < ApplicationController
         :title,
         :catch_copy,
         :concept,
-        prototype_image_attributes: [:id, :content, :role]
+        prototype_images_attributes: [:id, :content, :role]
       )
     end
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,12 +1,23 @@
 class PrototypesController < ApplicationController
 
+  before_action :move_to_index, except: :index
+
   def index
   end
 
   def new
+    @prototype = Prototype.new
+    # ↓後でmainとsubでbuild方法を変数に入れ直して、fields_forの第二引数に入れて区別する必要あり
+    # 理由としては、デフォルトで何かしらで画像が入っていないと、特にサブの場合変わったviewになる
+    @prototype.prototype_images.build
   end
 
   def show
   end
+
+  private
+    def move_to_index
+      redirect_to action: :index unless user_signed_in?
+    end
 
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,9 +15,27 @@ class PrototypesController < ApplicationController
   def show
   end
 
+  def create
+    @prototype = current_user.prototypes.new(prototype_params)
+    if @prototype.save
+      redirect_to root_path, notice: 'Saved prototype successfully'
+    else
+      render :new, alert: 'Sorry, but something went wrong'
+    end
+  end
+
   private
     def move_to_index
       redirect_to action: :index unless user_signed_in?
+    end
+
+    def prototype_params
+      params.require(:prototype).permit(
+        :title,
+        :catch_copy,
+        :concept,
+        prototype_image_attributes: [:id, :content, :role]
+      )
     end
 
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,0 +1,2 @@
+class Prototype < ActiveRecord::Base
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,2 +1,10 @@
 class Prototype < ActiveRecord::Base
+  belongs_to :user
+  has_many   :prototype_images, dependent: :destroy
+
+  accepts_nested_attributes_for :prototype_images, allow_destroy: true,
+                                                   reject_if: :all_blank
+  validates :title,
+            :catch_copy,
+            :concept, presence: true
 end

--- a/app/models/prototype_image.rb
+++ b/app/models/prototype_image.rb
@@ -1,2 +1,3 @@
 class PrototypeImage < ActiveRecord::Base
+  belongs_to :prototype
 end

--- a/app/models/prototype_image.rb
+++ b/app/models/prototype_image.rb
@@ -1,0 +1,2 @@
+class PrototypeImage < ActiveRecord::Base
+end

--- a/app/models/prototype_image.rb
+++ b/app/models/prototype_image.rb
@@ -1,3 +1,4 @@
 class PrototypeImage < ActiveRecord::Base
   belongs_to :prototype
+  enum role: %i{ main sub }
 end

--- a/app/models/prototype_image.rb
+++ b/app/models/prototype_image.rb
@@ -1,4 +1,5 @@
 class PrototypeImage < ActiveRecord::Base
   belongs_to :prototype
+  mount_uploader :content, PrototypeImageUploader
   enum role: %i{ main sub }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  has_many :prototypes
 
   validates :username, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX= /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i

--- a/app/uploaders/prototype_image_uploader.rb
+++ b/app/uploaders/prototype_image_uploader.rb
@@ -1,0 +1,17 @@
+class PrototypeImageUploader < CarrierWave::Uploader::Base
+
+  storage :file
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def default_url
+    "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  end
+
+  def extension_white_list
+    %w(jpg jpeg gif png)
+  end
+
+end

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -7,131 +7,13 @@
     .row
       %ul.nav.nav-pills.col-lg-11
         %li.active{ role: "presentation" }
-          %a{ href: "#" } Popular PROTO
+          = link_to 'Popular PROTO', "#"
         %li{ role: "presentation" }
-          %a{ href: "#" } Newest PROTO
-      %button{ type: "button", class: "btn btn-default col-lg-1" } View Tags
+          = link_to 'Newest PROTO', "#"
+      = button_tag 'View Tags', type: "button", class: "btn btn-default col-lg-1"
 
 .container.proto-list
   .row
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{ href: "/prototypes/show" }
-          = image_tag("sample.png")
-          .caption
-            %h3 Salvation Army on iPad App Wireframe
-            .proto-meta
-              .proto-user
-                %a{ href: "#" } by user
-              .proto-posted
-                Apr 26
-            %ul.proto-tag-list.list-inline
-              %li
-                %a{ href: "#", class: "btn btn-default" } iPad
-              %li
-                %a{ href: "#", class: "btn btn-default" } wireframe
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{ href: "/prototypes/show" }
-          = image_tag("sample.png")
-          .caption
-            %h3 Salvation Army on iPad App Wireframe
-            .proto-meta
-              .proto-user
-                %a{ href: "#" } by user
-              .proto-posted
-                Apr 26
-            %ul.proto-tag-list.list-inline
-              %li
-                %a{ href: "#", class: "btn btn-default" } iPad
-              %li
-                %a{ href: "#", class: "btn btn-default" } wireframe
-
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{ href: "/prototypes/show" }
-          = image_tag("sample.png")
-          .caption
-            %h3 Salvation Army on iPad App Wireframe
-            .proto-meta
-              .proto-user
-                %a{ href: "#" } by user
-              .proto-posted
-                Apr 26
-            %ul.proto-tag-list.list-inline
-              %li
-                %a{ href: "#", class: "btn btn-default" } iPad
-              %li
-                %a{ href: "#", class: "btn btn-default" } wireframe
-
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{ href: "/prototypes/show" }
-          = image_tag("sample.png")
-          .caption
-            %h3 Salvation Army on iPad App Wireframe
-            .proto-meta
-              .proto-user
-                %a{ href: "#" } by user
-              .proto-posted
-                Apr 26
-            %ul.proto-tag-list.list-inline
-              %li
-                %a{ href: "#", class: "btn btn-default" } iPad
-              %li
-                %a{ href: "#", class: "btn btn-default" } wireframe
-
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{ href: "/prototypes/show" }
-          = image_tag("sample.png")
-          .caption
-            %h3 Salvation Army on iPad App Wireframe
-            .proto-meta
-              .proto-user
-                %a{ href: "#" } by user
-              .proto-posted
-                Apr 26
-            %ul.proto-tag-list.list-inline
-              %li
-                %a{ href: "#", class: "btn btn-default" } iPad
-              %li
-                %a{ href: "#", class: "btn btn-default" } wireframe
-
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{ href: "/prototypes/show" }
-          = image_tag("sample.png")
-          .caption
-            %h3 Salvation Army on iPad App Wireframe
-            .proto-meta
-              .proto-user
-                %a{ href: "#" } by user
-              .proto-posted
-                Apr 26
-            %ul.proto-tag-list.list-inline
-              %li
-                %a{ href: "#", class: "btn btn-default" } iPad
-              %li
-                %a{ href: "#", class: "btn btn-default" } wireframe
-
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{ href: "/prototypes/show" }
-          = image_tag("sample.png")
-          .caption
-            %h3 Salvation Army on iPad App Wireframe
-            .proto-meta
-              .proto-user
-                %a{ href: "#" } by user
-              .proto-posted
-                Apr 26
-            %ul.proto-tag-list.list-inline
-              %li
-                %a{ href: "#", class: "btn btn-default" } iPad
-              %li
-                %a{ href: "#", class: "btn btn-default" } wireframe
-
     .col-sm-4.col-md-3.proto-content
       .thumbnail
         %a{ href: "/prototypes/show" }

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -1,36 +1,45 @@
-%form.container.proto-new{ action: "" }
-  .col-md-8.col-md-offset-2
-    %header.row.user-nav.row
-      .col-md-12
-        %input.proto-new-title{ type: "text", placeholder: "Title" }/
-    .row
-      .col-md-12
-        .cover-image-upload
-          %input{ type: "file" }/
-      .col-md-12
-        %ul.proto-sub-list.list-group
-          %li.list-group-item.col-md-4
-            .image-upload
-              %input{ type: "file" }/
-          %li.list-group-item.col-md-4
-            .image-upload
-              %input{ type: "file" }/
-          %li.list-group-item.col-md-4
-            .image-upload-plus
-              %span +
-    .row.proto-description
-      .col-md-12
-        %input{ type: "text", placeholder: "Catch Copy" }/
-      .col-md-12
-        %textarea{ name: "", cols: "30", rows: "4", placeholder: "Concept" }
-      .col-md-12
-        %h4 Tag List
-        .row
-          .col-md-3
-            %input{ type: "text", placeholder: "Web Design" }/
-          .col-md-3
-            %input{ type: "text", placeholder: "UI" }/
-          .col-md-3
-            %input{ type: "text", placeholder: "Application" }/
-    .row.text-center.proto-btn
-      %button.btn.btn-lg.btn-primary.btn-block{ type: "submit" } Publish
+.container.proto-new
+  = form_for @prototype do |f|
+    / ↓デフォルトでuser_idの値をセットしておく、hiddenは危険らしいけれど後で検討
+    = f.hidden_field :user_id, value: current_user.id
+    .col-md-8.col-md-offset-2
+      %header.row.user-nav.row
+        .col-md-12
+          = f.text_field :title, placeholder: "Title", class: "proto-new-title"
+      .row
+        .col-md-12
+          .cover-image-upload
+            / fields_forを利用してcontentにはイメージの名前、roleにはmainである0を入れる
+            = f.fields_for :prototype_images do |prototype_image|
+              = prototype_image.file_field :content
+              = prototype_image.hidden_field :role, value: "main"
+        .col-md-12
+          %ul.proto-sub-list.list-group
+            - 3.times do
+              %li.list-group-item.col-md-4
+                .image-upload
+                  / fields_forを利用してcontentにはイメージの名前、roleにはsubである1を入れる
+                  = f.fields_for :prototype_images do |prototype_image|
+                    = prototype_image.file_field :content
+                    = prototype_image.hidden_field :role, value: "sub"
+            / ↓今後の拡張性(subを3枚以上にする)のために残しておく？
+            / %li.list-group-item.col-md-4
+            /   .image-upload-plus
+            /     %span +
+      .row.proto-description
+        .col-md-12
+          = f.text_field :catch_copy, placeholder: "Catch Copy"
+        .col-md-12
+          = f.text_area :concept, cols: "30", rows: "4", placeholder: "Concept"
+        .col-md-12
+          %h4 Tag List
+          / tagの実装の際、フォームを書き換える
+          .row
+            .col-md-3
+              %input{ type: "text", placeholder: "Web Design" }/
+            .col-md-3
+              %input{ type: "text", placeholder: "UI" }/
+            .col-md-3
+              %input{ type: "text", placeholder: "Application" }/
+      .row.text-center.proto-btn
+        = f.submit "Publish", class: "btn btn-lg btn-primary btn-block"

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -10,18 +10,17 @@
         .col-md-12
           .cover-image-upload
             / fields_forを利用してcontentにはイメージの名前、roleにはmainである0を入れる
-            = f.fields_for :prototype_images do |prototype_image|
+            = f.fields_for :prototype_images, @main_content do |prototype_image|
               = prototype_image.file_field :content
               = prototype_image.hidden_field :role, value: "main"
         .col-md-12
           %ul.proto-sub-list.list-group
-            - 3.times do
+            / fields_forを利用してcontentにはイメージの名前、roleにはsubである1を入れる
+            = f.fields_for :prototype_images, @sub_contents do |prototype_image|
               %li.list-group-item.col-md-4
                 .image-upload
-                  / fields_forを利用してcontentにはイメージの名前、roleにはsubである1を入れる
-                  = f.fields_for :prototype_images do |prototype_image|
-                    = prototype_image.file_field :content
-                    = prototype_image.hidden_field :role, value: "sub"
+                  = prototype_image.file_field :content
+                  = prototype_image.hidden_field :role, value: "sub"
             / ↓今後の拡張性(subを3枚以上にする)のために残しておく？
             / %li.list-group-item.col-md-4
             /   .image-upload-plus

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -21,10 +21,6 @@
                 .image-upload
                   = prototype_image.file_field :content
                   = prototype_image.hidden_field :role, value: "sub"
-            / ↓今後の拡張性(subを3枚以上にする)のために残しておく？
-            / %li.list-group-item.col-md-4
-            /   .image-upload-plus
-            /     %span +
       .row.proto-description
         .col-md-12
           = f.text_field :catch_copy, placeholder: "Catch Copy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'prototypes#index'
   resources :users, only: [:show, :edit, :update]
-  resources :prototypes, only: [:new, :show]
+  resources :prototypes, only: [:index, :new, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'prototypes#index'
   resources :users, only: [:show, :edit, :update]
-  resources :prototypes, only: [:index, :new, :show]
+  resources :prototypes, only: [:index, :new, :show, :create]
 end

--- a/db/migrate/20160801070308_create_prototypes.rb
+++ b/db/migrate/20160801070308_create_prototypes.rb
@@ -1,0 +1,11 @@
+class CreatePrototypes < ActiveRecord::Migration
+  def change
+    create_table :prototypes do |t|
+      t.references :user, index: true, foreign_key: true
+      t.string     :title
+      t.string     :catch_copy
+      t.text       :concept
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160801071105_create_prototype_images.rb
+++ b/db/migrate/20160801071105_create_prototype_images.rb
@@ -1,0 +1,9 @@
+class CreatePrototypeImages < ActiveRecord::Migration
+  def change
+    create_table :prototype_images do |t|
+      t.references :prototype, index: true, foreign_key: true
+      t.text       :content
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160801073502_add_role_to_prototype_images.rb
+++ b/db/migrate/20160801073502_add_role_to_prototype_images.rb
@@ -1,0 +1,5 @@
+class AddRoleToPrototypeImages < ActiveRecord::Migration
+  def change
+    add_column :prototype_images, :role, :integer, default: 0, null: false, limit: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801071105) do
+ActiveRecord::Schema.define(version: 20160801073502) do
 
   create_table "prototype_images", force: :cascade do |t|
     t.integer  "prototype_id", limit: 4
     t.text     "content",      limit: 65535
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.integer  "role",         limit: 1,     default: 0, null: false
   end
 
   add_index "prototype_images", ["prototype_id"], name: "index_prototype_images_on_prototype_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160726151716) do
+ActiveRecord::Schema.define(version: 20160801071105) do
+
+  create_table "prototype_images", force: :cascade do |t|
+    t.integer  "prototype_id", limit: 4
+    t.text     "content",      limit: 65535
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "prototype_images", ["prototype_id"], name: "index_prototype_images_on_prototype_id", using: :btree
+
+  create_table "prototypes", force: :cascade do |t|
+    t.integer  "user_id",    limit: 4
+    t.string   "title",      limit: 255
+    t.string   "catch_copy", limit: 255
+    t.text     "concept",    limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  add_index "prototypes", ["user_id"], name: "index_prototypes_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255,   default: "", null: false
@@ -35,4 +55,6 @@ ActiveRecord::Schema.define(version: 20160726151716) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "prototype_images", "prototypes"
+  add_foreign_key "prototypes", "users"
 end


### PR DESCRIPTION
# WHAT
- carrierwaveの導入
- Prototype/PrototypeImageモデル、テーブルの作成
- プロトタイプ情報(親)とプロトタイプ画像(子)を一括で作成、更新
(accepts_nested_attributes_forメソッド、fields_forメソッドを使用)
- enumでmainとsubを分け、拡張性のためにnewアクションで変数化

# WHY
- 画像アップロード機能を実装するため
- プロトタイプ投稿し、画像をprototype_images テーブルに保存するため

# 期限
8/1