### PR TITLE
アバター画像投稿機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,8 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :member, :profile, :works])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :member, :profile, :works])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :member, :profile, :works, :avatar])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :member, :profile, :works, :avatar])
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,7 @@ class UsersController < ApplicationController
         :member,
         :profile,
         :works
+        :avatar
         )
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
         :password,
         :member,
         :profile,
-        :works
+        :works,
         :avatar
         )
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  mount_uploader :avatar, AvatarUploader
+
   has_many :prototypes
 
   validates :username, presence: true, length: { maximum: 50 }

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,17 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+
+  storage :file
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def default_url
+    "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  end
+
+  def extension_white_list
+    %w(jpg jpeg gif png)
+  end
+
+end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -7,7 +7,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   end
 
   def default_url
-    "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+    ActionController::Base.helpers.asset_path("default.png")
   end
 
   def extension_white_list

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -9,9 +9,7 @@
               = f.text_field :username, placeholder: "Username", required: true
             .user-image.col-md-2
               = f.button "Change image", class: "btn btn-primary"
-              / uploaders/avatarを利用する際に変更する↓
-              %input{ type: "file" }/
-              / = f.file_field :avatar
+              = f.file_field :avatar
           = f.email_field :email, placeholder: "E-Mail", class: "user-email"
           = f.password_field :password, placeholder: "Password", class: "user-password"
         .col-md-12

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -2,8 +2,7 @@
   %header.user-nav
     .media
       .media-left
-        %a{ href: "#" }
-          %img.media-object{ alt: "64x64", "data-holder-rendered": "true", "data-src": "holder.js/64x64", src: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+PGRlZnMvPjxyZWN0IHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgZmlsbD0iI0VFRUVFRSIvPjxnPjx0ZXh0IHg9IjEzLjQ2MDkzNzUiIHk9IjMyIiBzdHlsZT0iZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQ7ZG9taW5hbnQtYmFzZWxpbmU6Y2VudHJhbCI+NjR4NjQ8L3RleHQ+PC9nPjwvc3ZnPg==", style: "width: 64px; height: 64px;" }/
+        = link_to image_tag(@user.avatar, alt: "64x64", class: "media-object", style: "width: 64px; height: 64px;"), user_path(@user.id)
       .media-body
         %h4#top-aligned-media.media-heading
           = @user.username

--- a/db/migrate/20160802033308_add_avatar_to_users.rb
+++ b/db/migrate/20160802033308_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801073502) do
+ActiveRecord::Schema.define(version: 20160802033308) do
 
   create_table "prototype_images", force: :cascade do |t|
     t.integer  "prototype_id", limit: 4
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20160801073502) do
     t.text     "profile",                limit: 65535
     t.string   "member",                 limit: 255
     t.text     "works",                  limit: 65535
+    t.string   "avatar",                 limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
# WHAT
avatar uploaderを作成
新規登録、編集時に画像アップロード可能
# WHY
ユーザーがプロフィールで指定する画像を新規登録時、または編集時に登録、変更できるようにするため

## 期限
8/2