### PR TITLE
Newest/Popular機能の導入

### DIFF
--- a/app/controllers/prototypes/popular_controller.rb
+++ b/app/controllers/prototypes/popular_controller.rb
@@ -1,0 +1,2 @@
+class Prototypes::PopularController < ApplicationController
+end

--- a/app/controllers/prototypes/popular_controller.rb
+++ b/app/controllers/prototypes/popular_controller.rb
@@ -1,2 +1,6 @@
 class Prototypes::PopularController < ApplicationController
+  def index
+    @prototypes = Prototype.order("prototypes.like_count DESC").eager_load(:user, :prototype_images)
+    @status = 'popular'
+  end
 end

--- a/app/controllers/prototypes/popular_controller.rb
+++ b/app/controllers/prototypes/popular_controller.rb
@@ -1,6 +1,7 @@
 class Prototypes::PopularController < ApplicationController
   def index
-    @prototypes = Prototype.order("prototypes.like_count DESC").eager_load(:user, :prototype_images)
+    @prototypes = Prototype.order("prototypes.likes_count DESC").eager_load(:user, :prototype_images)
     @status = 'popular'
+    render 'prototypes/index'
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -5,6 +5,7 @@ class PrototypesController < ApplicationController
 
   def index
     @prototypes = Prototype.eager_load(:user, :prototype_images).order("prototypes.created_at DESC")
+    @status = 'newest'
   end
 
   def new

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -6,10 +6,10 @@
   .container
     .row
       %ul.nav.nav-pills.col-lg-11
-        %li.active{ role: "presentation" }
-          = link_to 'Popular PROTO', "#"
         %li{ role: "presentation" }
-          = link_to 'Newest PROTO', "#"
+          = link_to 'Popular PROTO', "#"
+        %li{ class: "#{ "active" if @status == 'newest' }" }
+          = link_to 'Newest PROTO', root_path
       = button_tag 'View Tags', type: "button", class: "btn btn-default col-lg-1"
 
 .container.proto-list

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -6,8 +6,8 @@
   .container
     .row
       %ul.nav.nav-pills.col-lg-11
-        %li{ role: "presentation" }
-          = link_to 'Popular PROTO', "#"
+        %li{ class: "#{ "active" if @status == 'popular' }" }
+          = link_to 'Popular PROTO', popular_index_path
         %li{ class: "#{ "active" if @status == 'newest' }" }
           = link_to 'Newest PROTO', root_path
       = button_tag 'View Tags', type: "button", class: "btn btn-default col-lg-1"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     scope module: :prototypes do
       resources :likes,    only: [:create, :destroy]
       resources :comments, only: [:create, :destroy]
+      resources :popular,  only: [:index]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
     scope module: :prototypes do
       resources :likes,    only: [:create, :destroy]
       resources :comments, only: [:create, :destroy]
-      resources :popular,  only: [:index]
     end
+  end
+  scope module: :prototypes do
+    resources :popular,  only: [:index]
   end
 end


### PR DESCRIPTION
# WHAT
- PrototypeのNewest / Popularの切り替え機能の実装

# WHY
- 新着順といいね順でそれぞれ表示するページを作るため

## HOW
- newestを作成→popularを作成

## 期限
8/7