### PR TITLE
Tag機能の導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ GitHub.sublime-settings
 *.jpg
 *.jpeg
 *.gif
+
+
+config/settings.yml

--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,4 @@ end
   gem 'devise'
   gem 'carrierwave'
   gem 'acts-as-taggable-on', '~> 3.4'
+  gem 'config'

--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,4 @@ end
   gem 'bootstrap-sass'
   gem 'devise'
   gem 'carrierwave'
+  gem 'acts-as-taggable-on', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,11 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    config (1.2.1)
+      activesupport (>= 3.0)
+      deep_merge (~> 1.0, >= 1.0.1)
     debug_inspector (0.0.2)
+    deep_merge (1.1.1)
     devise (4.2.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -204,6 +208,7 @@ DEPENDENCIES
   byebug
   carrierwave
   coffee-rails (~> 4.1.0)
+  config
   devise
   erb2haml
   haml-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (3.5.0)
+      activerecord (>= 3.2, < 5)
     arel (6.0.3)
     autoprefixer-rails (6.3.7)
       execjs
@@ -197,6 +199,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 3.4)
   bootstrap-sass
   byebug
   carrierwave

--- a/app/controllers/prototypes/tags_controller.rb
+++ b/app/controllers/prototypes/tags_controller.rb
@@ -1,0 +1,2 @@
+class Prototypes::TagsController < ApplicationController
+end

--- a/app/controllers/prototypes/tags_controller.rb
+++ b/app/controllers/prototypes/tags_controller.rb
@@ -4,5 +4,11 @@ class Prototypes::TagsController < ApplicationController
   end
 
   def show
+    @tag = ActsAsTaggableOn::Tag.find(params[:id])
+    @prototypes = Prototype.tagged_with(@tag).eager_load(:user, :prototype_images)
   end
 end
+
+# 確認3 eager_loadとincludeがなかなか使いこなせない。大きな違いは他のテーブルとの結合を必ずしたいかそうではないかなのですか？
+# 結果的に少ない方が良さそうなので両方試してsplの発行回数、合計時間を比べます。
+# 検証結果 eager_load (1.3 ms), includes (1.7 ms) よって、今回はeager_loadを使用

--- a/app/controllers/prototypes/tags_controller.rb
+++ b/app/controllers/prototypes/tags_controller.rb
@@ -1,2 +1,8 @@
 class Prototypes::TagsController < ApplicationController
+  def index
+    @tags = ActsAsTaggableOn::Tag.all
+  end
+
+  def show
+  end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -58,7 +58,9 @@ class PrototypesController < ApplicationController
         :catch_copy,
         :concept,
         prototype_images_attributes: [:id, :content, :role]
-      )
+      # 確認1 prototype.rbで定義したacts_as_taggableにより、prototype生成時に.merge(tag_list: )が利用することができる
+      # それにより、prototypes/new.html.hamlで入力した値がparams[:prototype][:tag][:ここに入力した値が入る]なり、tagsテーブルに保存される
+      ).merge(tag_list: params[:prototype][:tag])
     end
 
     def set_prototype

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -10,6 +10,9 @@ class Prototype < ActiveRecord::Base
             :catch_copy,
             :concept, presence: true
 
+  acts_as_taggable
+  acts_as_ordered_taggable_on :prototypes
+
   def liked_by?(user)
     likes.find_by(user_id: user)
   end

--- a/app/views/prototypes/_form.html.haml
+++ b/app/views/prototypes/_form.html.haml
@@ -25,13 +25,15 @@
           = f.text_area :concept, cols: "30", rows: "4", placeholder: "Concept"
         .col-md-12
           %h4 Tag List
-          / tagの実装の際、フォームを書き換える
           .row
             .col-md-3
-              %input{ type: "text", placeholder: "Web Design" }/
+              = text_field_tag "prototype[tag][]", "", placeholder: "Web Design"
             .col-md-3
-              %input{ type: "text", placeholder: "UI" }/
+              = text_field_tag "prototype[tag][]", "", placeholder: "UI"
             .col-md-3
-              %input{ type: "text", placeholder: "Application" }/
+              = text_field_tag "prototype[tag][]", "", placeholder: "Application"
       .row.text-center.proto-btn
         = f.submit "Publish", class: "btn btn-lg btn-primary btn-block"
+
+/ 確認2 上のtext_field_tagで→<input id="query", name="prototype[tag][]", type="text", value="", placeholder="Web Design"
+/ が生成される。その後ユーザーが入力した値がtags テーブルのnameに入り、tags/indexで格納されたものから順に表示される

--- a/app/views/prototypes/_form.html.haml
+++ b/app/views/prototypes/_form.html.haml
@@ -26,12 +26,9 @@
         .col-md-12
           %h4 Tag List
           .row
-            .col-md-3
-              = text_field_tag "prototype[tag][]", "", placeholder: "Web Design"
-            .col-md-3
-              = text_field_tag "prototype[tag][]", "", placeholder: "UI"
-            .col-md-3
-              = text_field_tag "prototype[tag][]", "", placeholder: "Application"
+            - Settings.tag_list_example.each do |tag|
+              .col-md-4
+                = text_field_tag "prototype[tag][]", "", placeholder: tag
       .row.text-center.proto-btn
         = f.submit "Publish", class: "btn btn-lg btn-primary btn-block"
 

--- a/app/views/prototypes/_prototype.html.haml
+++ b/app/views/prototypes/_prototype.html.haml
@@ -8,9 +8,7 @@
           = link_to "by #{prototype.user.username}", user_path(prototype.user.id), method: :get
         .proto-posted
           = prototype.created_at.strftime("%b %d")
-      / ↓tagを利用する際に編集
       %ul.proto-tag-list.list-inline
-        %li
-          = link_to 'iPad', '#', class: "btn btn-default"
-        %li
-          = link_to 'wireframe', '#', class: "btn btn-default"
+        - prototype.tags.each do |tag|
+          %li
+            = link_to tag.name, tag_path(tag.id), class: "btn btn-default"

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -10,7 +10,7 @@
           = link_to 'Popular PROTO', popular_index_path
         %li{ class: "#{ "active" if @status == 'newest' }" }
           = link_to 'Newest PROTO', root_path
-      = button_tag 'View Tags', type: "button", class: "btn btn-default col-lg-1"
+      = link_to 'View Tags', tags_path, class: "btn btn-default col-lg-1"
 
 .container.proto-list
   .row

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -35,10 +35,9 @@
     .col-md-3
       %h4 Tag List
       %ul.proto-tag-list.list-inline
-        %li
-          %a{ href: "#", class: "btn btn-default"} iPad
-        %li
-          %a{ href: "#", class: "btn btn-default"} wireframe
+        - @prototype.tags.each do |tag|
+          %li
+            = link_to tag.name, tag_path(tag.id), class: "btn btn-default"
   .row.proto-comments
     %h4.col-md-12
       Comments

--- a/app/views/prototypes/tags/index.html.haml
+++ b/app/views/prototypes/tags/index.html.haml
@@ -14,21 +14,9 @@
 
 .container
   .row
-    .col-sm-4.col-sm-3
-      %a.tag.thumbnail{href: "/tags/1"}
-        .tag-name
-          web
-        .tag-project
-          1 project
-    .col-sm-4.col-sm-3
-      %a.tag.thumbnail{href: "/tags/2"}
-        .tag-name
-          iOS
-        .tag-project
-          1 project
-    .col-sm-4.col-sm-3
-      %a.tag.thumbnail{href: "/tags/3"}
-        .tag-name
-          Design
-        .tag-project
-          1 project
+    %ul.proto-tag-list.list-inline
+      - @tags.each do |tag|
+        .col-sm-4.tag.thumbnail
+          = link_to tag.name, tag_path(tag.id), class: "tag-name btn btn-default btn-tag"
+          .tag-project
+            = link_to "#{tag.taggings_count} Projects", tag_path(tag.id), class: "btn btn-default btn-tag"

--- a/app/views/prototypes/tags/index.html.haml
+++ b/app/views/prototypes/tags/index.html.haml
@@ -1,0 +1,34 @@
+.jumbotron
+  .container.text-center
+    = image_tag("header_logo.png", alt: "PROTO TYPE - SHARE THE PROTOTYPE", height: "73px")
+
+.filter-nav
+  .container
+    .row
+      %ul.nav.nav-pills.col-lg-11
+        %li{ class: "#{ "active" if @status == 'popular' }" }
+          = link_to 'Popular PROTO', popular_index_path
+        %li{ class: "#{ "active" if @status == 'newest' }" }
+          = link_to 'Newest PROTO', root_path
+      = link_to 'View Tags', tags_path, class: "btn btn-default col-lg-1"
+
+.container
+  .row
+    .col-sm-4.col-sm-3
+      %a.tag.thumbnail{href: "/tags/1"}
+        .tag-name
+          web
+        .tag-project
+          1 project
+    .col-sm-4.col-sm-3
+      %a.tag.thumbnail{href: "/tags/2"}
+        .tag-name
+          iOS
+        .tag-project
+          1 project
+    .col-sm-4.col-sm-3
+      %a.tag.thumbnail{href: "/tags/3"}
+        .tag-name
+          Design
+        .tag-project
+          1 project

--- a/app/views/prototypes/tags/show.html.haml
+++ b/app/views/prototypes/tags/show.html.haml
@@ -14,17 +14,4 @@
 
 .container
   .row
-    .tag-header
-      %span # web
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{href: "/prototypes/10"}
-          %img{alt: " ", src: "milano.jpg"}/
-        .caption
-          %h3
-            aaa post!!!!!![test version]
-          .proto-meta
-            .proto-user
-              %a{href: "/users/1"} by aaa
-            .proto-posted
-              Jun 10 
+    = render partial: "prototypes/prototype", collection: @prototypes

--- a/app/views/prototypes/tags/show.html.haml
+++ b/app/views/prototypes/tags/show.html.haml
@@ -1,0 +1,30 @@
+.jumbotron
+  .container.text-center
+    = image_tag("header_logo.png", alt: "PROTO TYPE - SHARE THE PROTOTYPE", height: "73px")
+
+.filter-nav
+  .container
+    .row
+      %ul.nav.nav-pills.col-lg-11
+        %li{ class: "#{ "active" if @status == 'popular' }" }
+          = link_to 'Popular PROTO', popular_index_path
+        %li{ class: "#{ "active" if @status == 'newest' }" }
+          = link_to 'Newest PROTO', root_path
+      = link_to 'View Tags', tags_path, class: "btn btn-default col-lg-1"
+
+.container
+  .row
+    .tag-header
+      %span # web
+    .col-sm-4.col-md-3.proto-content
+      .thumbnail
+        %a{href: "/prototypes/10"}
+          %img{alt: " ", src: "milano.jpg"}/
+        .caption
+          %h3
+            aaa post!!!!!![test version]
+          .proto-meta
+            .proto-user
+              %a{href: "/users/1"} by aaa
+            .proto-posted
+              Jun 10 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   scope module: :prototypes do
     resources :popular,  only: [:index]
   end
+  resources :tags, only: [:index, :show], module: :prototypes
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,4 @@
+tag_list_example:
+  - 'Web Design'
+  - 'UI'
+  - 'Application'

--- a/db/migrate/20160808075934_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160808075934_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,31 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20160808075935_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160808075935_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20160808075936_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160808075936_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20160808075937_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160808075937_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20160808075938_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160808075938_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160806115453) do
+ActiveRecord::Schema.define(version: 20160808075938) do
 
   create_table "comments", force: :cascade do |t|
     t.integer  "user_id",      limit: 4
@@ -55,6 +55,26 @@ ActiveRecord::Schema.define(version: 20160806115453) do
   end
 
   add_index "prototypes", ["user_id"], name: "index_prototypes_on_user_id", using: :btree
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id",        limit: 4
+    t.integer  "taggable_id",   limit: 4
+    t.string   "taggable_type", limit: 255
+    t.integer  "tagger_id",     limit: 4
+    t.string   "tagger_type",   limit: 255
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+  end
+
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+
+  create_table "tags", force: :cascade do |t|
+    t.string  "name",           limit: 255
+    t.integer "taggings_count", limit: 4,   default: 0
+  end
+
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255,   default: "", null: false


### PR DESCRIPTION
# WHAT
- gem acts-as-taggable-onの導入
- プロトタイプ投稿時にタグ登録機能の実装

## rootからの流れ（3パターン）
- tagの一覧を表示（prototypes/tags/index）
 - / → /tags → /tags/1
- 各tagにおけるプロトタイプ一覧機能の実装（prototypes/tags/show）
 - / → /tags/1
- 各プロトタイプ詳細（prototypes/show）からの各タグへの詳細一覧(prototypes/tags/show)
 - / → /prototypes/1 → tags/1

# WHY
- ユーザーがプロトタイプ投稿時にタグを紐付けることができるようにするため
- タグの一覧を表示するため
- 同じタグに紐付いているプロトタイプ一覧を表示するため

### 期限
- 8/8