### PR TITLE
画像Preview機能

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,5 +13,4 @@
 //= require jquery
 //= require bootstrap-sprockets
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/preview_image.js
+++ b/app/assets/javascripts/preview_image.js
@@ -1,0 +1,5 @@
+$(function() {
+  $('.js-preview-image').each(function() {
+    // ここに処理を書いていく
+  });
+});

--- a/app/assets/javascripts/preview_image.js
+++ b/app/assets/javascripts/preview_image.js
@@ -1,5 +1,16 @@
 $(function() {
   $('.js-preview-image').each(function() {
-    // ここに処理を書いていく
+    var preview = $(this);
+    var prototype_image = $(this).find('input[type=file]');
+    prototype_image.change(function() {
+      var file = this.files[0]
+      var fileReader = new FileReader();
+      fileReader.onload = function() {
+        preview.css({
+          'background-image': 'url(' + fileReader.result + ')'
+        });
+      };
+      fileReader.readAsDataURL(file);
+    });
   });
 });

--- a/app/assets/javascripts/preview_image.js
+++ b/app/assets/javascripts/preview_image.js
@@ -1,15 +1,27 @@
 $(function() {
   $('.js-preview-image').each(function() {
-    var preview = $(this);
-    var prototype_image = $(this).find('input[type=file]');
+    const preview = $(this);
+    const prototype_image = $(this).find('input[type=file]');
     prototype_image.change(function() {
+      // 1. 選択されたファイルがない場合は何もせずにerrorをアラートで出す
+      if (!this.files.length) {
+        alert('No file selected')
+      }
+      // 2. files配列にファイルが入っており、変数fileへ代入
       var file = this.files[0]
-      var fileReader = new FileReader();
+      // 3. 画像ファイル以外は表示できない
+      if (!file.type.match('image.*')) {
+        alert('Upload image file only')
+      }
+      // 4. fileを読み込むFileReaderオブジェクト
+      const fileReader = new FileReader();
+      // 5. 読み込みが完了した際のイベントハンドラ。
       fileReader.onload = function() {
         preview.css({
           'background-image': 'url(' + fileReader.result + ')'
         });
       };
+      // 6. 画像読み込み
       fileReader.readAsDataURL(file);
     });
   });

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -2,3 +2,4 @@
 @import "bootstrap";
 @import "protospace";
 @import "custom";
+@import "preview-image";

--- a/app/assets/stylesheets/preview-image.css.scss
+++ b/app/assets/stylesheets/preview-image.css.scss
@@ -1,0 +1,7 @@
+.js-preview-image {
+  height: 100%;
+  width: 100%;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -10,7 +10,8 @@
               = f.text_field :username, autofocus: true, placeholder: "Username", required: true
             .user-image.col-md-2
               = f.button "Add image", class: "btn btn-primary"
-              = f.file_field :avatar
+              .js-preview-image
+                = f.file_field :avatar
           .user-email
             = f.email_field :email, placeholder: "E-Mail"
           .user-password

--- a/app/views/prototypes/_form.html.haml
+++ b/app/views/prototypes/_form.html.haml
@@ -9,15 +9,17 @@
         .col-md-12
           .cover-image-upload
             = f.fields_for :prototype_images, @main_content do |prototype_image|
-              = prototype_image.file_field :content
-              = prototype_image.hidden_field :role, value: "main"
+              .js-preview-image
+                = prototype_image.file_field :content
+                = prototype_image.hidden_field :role, value: "main"
         .col-md-12
           %ul.proto-sub-list.list-group
             = f.fields_for :prototype_images, @sub_contents do |prototype_image|
               %li.list-group-item.col-md-4
                 .image-upload
-                  = prototype_image.file_field :content
-                  = prototype_image.hidden_field :role, value: "sub"
+                  .js-preview-image
+                    = prototype_image.file_field :content
+                    = prototype_image.hidden_field :role, value: "sub"
       .row.proto-description
         .col-md-12
           = f.text_field :catch_copy, placeholder: "Catch Copy"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -9,7 +9,8 @@
               = f.text_field :username, placeholder: "Username", required: true
             .user-image.col-md-2
               = f.button "Change image", class: "btn btn-primary"
-              = f.file_field :avatar
+              .js-preview-image
+                = f.file_field :avatar
           = f.email_field :email, placeholder: "E-Mail", class: "user-email"
           = f.password_field :password, placeholder: "Password", class: "user-password"
         .col-md-12


### PR DESCRIPTION
# WHAT
- FileAPIを利用し、画像のプレビュー機能実装
- プロトタイプの新規登録、編集時に投稿画像をPreviewすることができる
- ユーザーの新規登録、編集時にアバター画像をPreviewすることができる

# WHY
- 画像を投稿する際に、非同期で表示して視覚的に確認するため
- アバターを設定する際に、非同期で表示して視覚的に確認するため

## 期限
8/10

### 機能実装手順
１　jsのファイル作成(preview_image.js)
２　各箇所にクラス指定(.js-preview-image)
３　jsに適用させるcssファイル作成(preview-image.css.scss)
４　新規cssファイルを適用させるために＠import追記(application.css.scss)
５　jsファイルに処理のコーディング(FileAPIに沿って)
６　動作確認(Gyazo)
７　修正