### PR TITLE
ページネーションの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,4 @@ end
   gem 'carrierwave'
   gem 'acts-as-taggable-on', '~> 3.4'
   gem 'config'
+  gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -214,6 +217,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari
   mysql2 (= 0.3.18)
   pry-rails
   rails (= 4.2.5)

--- a/app/controllers/prototypes/popular_controller.rb
+++ b/app/controllers/prototypes/popular_controller.rb
@@ -1,6 +1,6 @@
 class Prototypes::PopularController < ApplicationController
   def index
-    @prototypes = Prototype.order("prototypes.likes_count DESC").eager_load(:user, :prototype_images)
+    @prototypes = Prototype.order("prototypes.likes_count DESC").eager_load(:user, :prototype_images).page(params[:page])
     @status = 'popular'
     render 'prototypes/index'
   end

--- a/app/controllers/prototypes/tags_controller.rb
+++ b/app/controllers/prototypes/tags_controller.rb
@@ -5,10 +5,6 @@ class Prototypes::TagsController < ApplicationController
 
   def show
     @tag = ActsAsTaggableOn::Tag.find(params[:id])
-    @prototypes = Prototype.tagged_with(@tag).eager_load(:user, :prototype_images)
+    @prototypes = Prototype.tagged_with(@tag).eager_load(:user, :prototype_images).page(params[:page])
   end
 end
-
-# 確認3 eager_loadとincludeがなかなか使いこなせない。大きな違いは他のテーブルとの結合を必ずしたいかそうではないかなのですか？
-# 結果的に少ない方が良さそうなので両方試してsplの発行回数、合計時間を比べます。
-# 検証結果 eager_load (1.3 ms), includes (1.7 ms) よって、今回はeager_loadを使用

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -4,7 +4,7 @@ class PrototypesController < ApplicationController
   before_action :set_prototype, only: [:show, :edit, :update, :destroy]
 
   def index
-    @prototypes = Prototype.eager_load(:user, :prototype_images).order("prototypes.created_at DESC")
+    @prototypes = Prototype.eager_load(:user, :prototype_images).order("prototypes.created_at DESC").page(params[:page])
     @status = 'newest'
   end
 

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -13,6 +13,8 @@ class Prototype < ActiveRecord::Base
   acts_as_taggable
   acts_as_ordered_taggable_on :prototypes
 
+  paginates_per 5
+
   def liked_by?(user)
     likes.find_by(user_id: user)
   end

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.disabled
+  = content_tag :a, raw(t 'views.pagination.truncate')

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.active
+    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+- else
+  %li
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,11 @@
+= paginator.render do
+  %ul.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.left_outer? || page.right_outer? || page.inside_window?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -19,20 +19,4 @@
 .text-center
   %ul.pagination
     %li.disabled
-      %a{ "aria-label" => "Previous", href: "#" }
-        %span{ "aria-hidden" => "true" } «
-    %li.active
-      %a{ href: "#" }
-        1
-        %span.sr-only (current)
-    %li
-      %a{ href: "#" } 2
-    %li
-      %a{ href: "#" } 3
-    %li
-      %a{ href: "#" } 4
-    %li
-      %a{ href: "#" } 5
-    %li
-      %a{ "aria-label": "Next", href: "#" }
-        %span{ "aria-hidden": "true" } »
+      = paginate(@prototypes)

--- a/app/views/prototypes/tags/show.html.haml
+++ b/app/views/prototypes/tags/show.html.haml
@@ -15,3 +15,7 @@
 .container
   .row
     = render partial: "prototypes/prototype", collection: @prototypes
+.text-center
+  %ul.pagination
+    %li.disabled
+      = paginate(@prototypes)

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,2 @@
+Kaminari.configure do |config|
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -60,3 +60,19 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  views:
+    pagination:
+      first:    "&laquo;"
+      last:     "&raquo;"
+      previous: "&lsaquo;"
+      next:     "&rsaquo;"
+      truncate: "&hellip;"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "No %{entry_name} found"
+          one: "Displaying <b>1</b> %{entry_name}"
+          other: "Displaying <b>all %{count}</b> %{entry_name}"
+      more_pages:
+        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"


### PR DESCRIPTION
# WHAT
- kaminariの導入
- paginationの実装
 - prototypes/index の popularとnewest
 - prototypes/tags/show の show
- perをモデルで定義し、冗長化を防ぐ

# WHY
- Prototypeの項目数が5以上(暫定的)になる際に、次のページへ遷移し他のPrototypeを見れるようにするため
- Bootstrap3を加え、ボタンにうまく装飾を加える

## 期限
8/10